### PR TITLE
[Service dashboard] Fix missing metrics & improve active request graph

### DIFF
--- a/dashboards/datalayer-service.json
+++ b/dashboards/datalayer-service.json
@@ -1,67 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
-      "name": "DS_LOKI",
-      "label": "Loki",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "loki",
-      "pluginName": "Loki"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.1.0"
-    },
-    {
-      "type": "panel",
-      "id": "logs",
-      "name": "Logs",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "loki",
-      "name": "Loki",
-      "version": "1.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -87,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -141,11 +77,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(fastapi_requests_total{app_name=\"$service_name\", path!=\"/metrics\"})",
+          "expr": "sum(http_server_duration_milliseconds_count{service_name=\"$service_name\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -181,6 +117,9 @@
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -203,11 +142,12 @@
       },
       "id": 16,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -215,20 +155,20 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
       "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "http_server_active_requests{service_name=\"$service_name\"}",
+          "expr": "sum by(http_method, http_route) (http_server_duration_milliseconds_count{service_name=\"$service_name\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{http_method}} {{http_route}}",
@@ -263,7 +203,7 @@
           }
         }
       ],
-      "type": "stat"
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -323,7 +263,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -394,12 +334,14 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "fastapi_exceptions_total{app_name=\"$service_name\"}",
+          "expr": "sum(http_server_duration_milliseconds_count{service_name=\"$service_name\",http_status_code=~\"5..\"})",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -491,13 +433,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(http_route) (http_server_duration_milliseconds_sum{service_name=\"$service_name\",http_status_code=~\"2..\"}) / sum by(http_route) (http_server_duration_milliseconds_sum{service_name=\"$service_name\"})",
+          "expr": "sum by(http_route, http_method) (http_server_duration_milliseconds_sum{service_name=\"$service_name\",http_status_code=~\"2..\"}) / sum by(http_route, http_method) (http_server_duration_milliseconds_sum{service_name=\"$service_name\"})",
           "interval": "",
-          "legendFormat": "{{http_route}}",
+          "legendFormat": "{{http_method}} {{http_route}}",
           "range": true,
           "refId": "A"
         }
@@ -589,13 +531,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(http_route) (http_server_duration_milliseconds_sum{service_name=\"$service_name\",http_status_code=~\"5..\"}) / sum by(http_route) (http_server_duration_milliseconds_sum{service_name=\"$service_name\"})",
+          "expr": "sum by(http_route, http_method) (http_server_duration_milliseconds_sum{service_name=\"$service_name\",http_status_code=~\"5..\"}) / sum by(http_route, http_method) (http_server_duration_milliseconds_sum{service_name=\"$service_name\"})",
           "interval": "",
-          "legendFormat": "{{path}}",
+          "legendFormat": "{{http_method}} {{http_route}}",
           "range": true,
           "refId": "A"
         }
@@ -689,7 +631,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -785,7 +727,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -886,11 +828,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(http_server_active_requests{service_name=\"$service_name\"}[1m])",
+          "expr": "rate(http_server_duration_milliseconds_count{service_name=\"$service_name\"}[10m])",
           "interval": "",
           "legendFormat": "{{http_method}}{{http_route}}",
           "range": true,
@@ -1029,7 +971,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "${logs_source}"
           },
           "editorMode": "code",
           "expr": "sum by(type) (rate({service_name=\"$service_name\"} | pattern `<date> <time> <type> <logger> <code> [trace_id=<trace_id> span_id=<span_id> resource.service.name=<service_name> <_>] - <msg>` | type != \"\" |= \"$log_keyword\" [1m]))",
@@ -1068,7 +1010,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "${logs_source}"
           },
           "editorMode": "code",
           "expr": "{service_name=\"$service_name\"} | pattern `<date> <time> <type> <logger> <code> [trace_id=<trace_id> span_id=<span_id> resource.service.name=<service_name> <_>] - <msg>` | line_format \"{{.service_name}}\\t{{.type}}\\t trace_id={{.trace_id}}\\t {{.msg}}\" |= \"$log_keyword\"",
@@ -1089,7 +1031,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Data source",
@@ -1097,13 +1043,18 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "Loki",
+          "value": "loki"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Logs source",
@@ -1118,7 +1069,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "iam",
           "value": "iam"
         },
@@ -1170,6 +1121,6 @@
   "timezone": "",
   "title": "Services",
   "uid": "ad5e35f5cdc892317c4b7e4f321c402c",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }


### PR DESCRIPTION
Drop using active request metrics as the request are too fast. Use instead request duration histogram count.

This allows:
- to display the aggregated sum of requests
- compute a realistic request rate
- compute active request count for the past day

The service dashboard looks like this after this PR:

![image](https://github.com/user-attachments/assets/4ed6ba8c-a9f6-4bd8-bd06-a7acc45c0cb5)

Prior it was

![](https://datalayer-assets.s3.amazonaws.com/observer/observer-services.png)

Fixes https://github.com/datalayer/services/issues/250